### PR TITLE
fix: cms preview template

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -99,7 +99,6 @@ module.exports = {
        resolve: 'gatsby-plugin-netlify-cms',
        options: {
          modulePath: `${__dirname}/src/cms/cms.js`,
-         stylesPath: `${__dirname}/src/global.scss`
        },
      },
      `gatsby-plugin-offline`,

--- a/src/cms/cms.js
+++ b/src/cms/cms.js
@@ -2,4 +2,4 @@ import CMS from 'netlify-cms-app'
 
 import IndexPagePreview from './preview-templates/IndexPagePreview'
 
-CMS.registerPreviewTemplate('index', IndexPagePreview)
+CMS.registerPreviewTemplate('home', IndexPagePreview)


### PR DESCRIPTION
Fix preview template.
Context: https://community.netlify.com/t/understanding-custom-previews/11099

For file collections one needs to use the name of the file:
https://www.netlifycms.org/docs/customization/#registerpreviewtemplate